### PR TITLE
Caution about relative URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ To add your feed -:
 ```
 * Create a pull request 
 
+Note that certain static site generators like hugo may generate feeds with relative URLs. This does not conform to the [standard](https://validator.w3.org/feed/docs/error/InvalidFullLink.html) and your listings will be erroneous. Read [this answer](https://stackoverflow.com/a/48457055/2251364) for a possible solution.
+
 ## Basic Guidlines for the Planet
 This Planet is kind of an impression of the ILUGD volunteers hence you are required to follow some basic guidelines and the [COC](https://github.com/ILUGD/Code-of-Conduct).
 


### PR DESCRIPTION
1) It is a known issue in pluto https://github.com/feedreader/pluto/issues/15 , long time no see. I don't think it'll be fixed

2) It's not really an issue at pluto side. w3c says you cannot have relative links in feeds. For instance: https://validator.w3.org/feed/check.cgi?url=https://m47r1x.github.io/index.xml (this might not show errors later today, I pushed a fix, try the other one)

3) Here is a possible solution for hugo users. idk about others tho https://stackoverflow.com/questions/48414410/control-index-xml-for-atom-rss-hugo-blogdown-generates-feed-with-relative-lin

Signed-off-by: Hritik Vijay <hritikxx8@gmail.com>