### PR TITLE
Make only valid feeds visible

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -31,7 +31,9 @@ module.exports = function (eleventyConfig) {
       )
       .value();
     const res = await Promise.all(allFeeds);
-    return movePinFeedsToTop(sortFeedByLatestPost(res));
+    // passthrough only valid feeds
+    const validFeeds = res.filter((feed) => Object.keys(feed.data.feedData).length !== 0);
+    return movePinFeedsToTop(sortFeedByLatestPost(validFeeds));
   });
 
   return {


### PR DESCRIPTION
Earlier, if one of the feeds went offline or some error occured while parsing that feed, it would lead to all the feeds' html not being generated. The CI build would fail and updated articles wouldn't show on the website :)